### PR TITLE
[Feat] 닉네임 텍스트필드 Invalid 말풍선 추가

### DIFF
--- a/app/src/main/java/com/example/findu/presentation/ui/onboarding/component/OnboardingNickname.kt
+++ b/app/src/main/java/com/example/findu/presentation/ui/onboarding/component/OnboardingNickname.kt
@@ -43,6 +43,12 @@ fun OnboardingNickname(
     nicknameValidState: NicknameValidType = NicknameValidType.IDLE,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val nicknameTextBoxVisible =
+        nicknameValidState in setOf(
+            NicknameValidType.EMPTY_INVALID,
+            NicknameValidType.FORMAT_INVALID,
+            NicknameValidType.DUPLICATE_INVALID
+        )
     val isFocused by interactionSource.collectIsFocusedAsState()
 
     LaunchedEffect(isFocused) {
@@ -135,6 +141,7 @@ fun OnboardingNickname(
             ),
             style = FindUTheme.typography.captionRegular12
         )
+        OnboardingNicknameTextBox(modifier = Modifier.align(Alignment.End), isVisible = nicknameTextBoxVisible)
     }
 }
 

--- a/app/src/main/java/com/example/findu/presentation/ui/onboarding/component/OnboardingNicknameTextBox.kt
+++ b/app/src/main/java/com/example/findu/presentation/ui/onboarding/component/OnboardingNicknameTextBox.kt
@@ -12,16 +12,18 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.findu.R
 import com.example.findu.presentation.util.extension.roundedBackgroundWithPadding
 import com.example.findu.presentation.util.shape.TriangleShape
 import com.example.findu.ui.theme.FindUTheme
 
 @Composable
-fun OnboardingNicknameTextBox(modifier: Modifier = Modifier,isVisible:Boolean = false) {
-    if (isVisible){
+fun OnboardingNicknameTextBox(modifier: Modifier = Modifier, isVisible: Boolean = false) {
+    if (isVisible) {
         Column(modifier = modifier) {
             Spacer(
                 modifier = Modifier
@@ -41,10 +43,7 @@ fun OnboardingNicknameTextBox(modifier: Modifier = Modifier,isVisible:Boolean = 
                     .align(Alignment.End)
             ) {
                 Text(
-                    text = "다음과 같은 경우에 불가능해요.\n" +
-                            " 1. 중복된 닉네임인 경우\n" +
-                            " 2. 띄어쓰기만 있는 닉네임인 경우\n" +
-                            " 3. 특수문자(!@#\$,.^)가 포함되어 있는 경우",
+                    text = stringResource(R.string.onboarding_invalid_text_box),
                     style = FindUTheme.typography.captionRegular12.copy(
                         lineHeight = 20.sp
                     ),

--- a/app/src/main/java/com/example/findu/presentation/ui/onboarding/component/OnboardingNicknameTextBox.kt
+++ b/app/src/main/java/com/example/findu/presentation/ui/onboarding/component/OnboardingNicknameTextBox.kt
@@ -1,0 +1,62 @@
+package com.example.findu.presentation.ui.onboarding.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.findu.presentation.util.extension.roundedBackgroundWithPadding
+import com.example.findu.presentation.util.shape.TriangleShape
+import com.example.findu.ui.theme.FindUTheme
+
+@Composable
+fun OnboardingNicknameTextBox(modifier: Modifier = Modifier,isVisible:Boolean = false) {
+    if (isVisible){
+        Column(modifier = modifier) {
+            Spacer(
+                modifier = Modifier
+                    .padding(end = 28.dp)
+                    .size(15.dp)
+                    .offset(y = 2.dp)
+                    .background(shape = TriangleShape(), color = FindUTheme.colors.gray2)
+                    .align(Alignment.End)
+            )
+            Box(
+                modifier = Modifier
+                    .roundedBackgroundWithPadding(
+                        backgroundColor = FindUTheme.colors.gray2,
+                        cornerRadius = 8.dp,
+                        padding = PaddingValues(15.dp)
+                    )
+                    .align(Alignment.End)
+            ) {
+                Text(
+                    text = "다음과 같은 경우에 불가능해요.\n" +
+                            " 1. 중복된 닉네임인 경우\n" +
+                            " 2. 띄어쓰기만 있는 닉네임인 경우\n" +
+                            " 3. 특수문자(!@#\$,.^)가 포함되어 있는 경우",
+                    style = FindUTheme.typography.captionRegular12.copy(
+                        lineHeight = 20.sp
+                    ),
+                    color = FindUTheme.colors.gray5
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OnboardingNicknameTextBoxPreview() {
+    OnboardingNicknameTextBox(isVisible = true)
+}

--- a/app/src/main/java/com/example/findu/presentation/util/shape/TriangleShpae.kt
+++ b/app/src/main/java/com/example/findu/presentation/util/shape/TriangleShpae.kt
@@ -1,0 +1,24 @@
+package com.example.findu.presentation.util.shape
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.math.sqrt
+
+class TriangleShape : Shape {
+    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density): Outline {
+        val width = size.width
+        val height = (sqrt(3.0) / 2 * width).toFloat()
+
+        val path = Path().apply {
+            moveTo(width / 2f, 0f)
+            lineTo(0f, height)
+            lineTo(width, height)
+            close()
+        }
+        return Outline.Generic(path)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -424,6 +424,7 @@
     <string name="onboarding_profile_title_first">프로필을</string>
     <string name="onboarding_profile_title_second">정해주세요!</string>
     <string name="onboarding_next_button_text">다음</string>
+    <string name="onboarding_invalid_text_box">다음과 같은 경우에 불가능해요.\n 1. 중복된 닉네임인 경우\n 2. 띄어쓰기만 있는 닉네임인 경우\n 3. 특수문자(!@#$,.^)가 포함되어 있는 경우</string>
 
 
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #68 

## Work Description 📝
- 닉네임 텍스트 필드의 State가 Invalid일 때 나타나는 말풍선을 추가합니다

## Screenshot 📸

https://github.com/user-attachments/assets/9fcd4639-56be-4bcb-aff9-1c233784616f



## Uncompleted Tasks 😅
- [ ] N/A

## To Reviewers 📢
