### PR TITLE
[Feat] 로그인 API 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,6 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "BASE_URL", properties["base.url"].toString())
         buildConfigField("String", "GPT_KEY", properties["GPT_KEY"].toString())
         manifestPlaceholders["NAVER_CLIENT_ID"] = properties["NAVER_CLIENT_ID"].toString()
         buildConfigField("String", "NAVER_CLIENT_ID", properties["NAVER_CLIENT_ID"].toString())
@@ -37,10 +36,18 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = false
+            buildConfigField("String", "BASE_URL", properties["base.url.release"].toString())
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+        }
+        debug {
+            isMinifyEnabled = false
+            isDebuggable = true
+            versionNameSuffix = "-DEBUG"
+            buildConfigField("String", "BASE_URL", properties["base.url.dev"].toString())
+
         }
     }
     buildFeatures {

--- a/app/src/main/java/com/example/findu/data/dataremote/datasource/AuthRemoteDataSource.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/datasource/AuthRemoteDataSource.kt
@@ -1,14 +1,15 @@
 package com.example.findu.data.dataremote.datasource
 
 import com.example.findu.data.dataremote.model.base.BaseResponse
+import com.example.findu.data.dataremote.model.request.LoginRequestDto
 import com.example.findu.data.dataremote.model.response.CheckEmailResponseDto
+import com.example.findu.data.dataremote.model.response.auth.LoginResponseDto
 import retrofit2.Response
 
 interface AuthRemoteDataSource {
     suspend fun postLogin(
-        email: String,
-        password: String
-    ): Response<Unit>
+        loginRequestDto: LoginRequestDto
+    ): BaseResponse<LoginResponseDto>
 
     suspend fun postCheckEmail(
         email: String

--- a/app/src/main/java/com/example/findu/data/dataremote/datasource/AuthRemoteDataSource.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/datasource/AuthRemoteDataSource.kt
@@ -1,8 +1,10 @@
 package com.example.findu.data.dataremote.datasource
 
 import com.example.findu.data.dataremote.model.base.BaseResponse
+import com.example.findu.data.dataremote.model.request.GuestLoginRequestDto
 import com.example.findu.data.dataremote.model.request.LoginRequestDto
 import com.example.findu.data.dataremote.model.response.CheckEmailResponseDto
+import com.example.findu.data.dataremote.model.response.auth.GuestLoginResponseDto
 import com.example.findu.data.dataremote.model.response.auth.LoginResponseDto
 import retrofit2.Response
 
@@ -10,6 +12,10 @@ interface AuthRemoteDataSource {
     suspend fun postLogin(
         loginRequestDto: LoginRequestDto
     ): BaseResponse<LoginResponseDto>
+
+    suspend fun postGuestLogin(
+        guestLoginRequestDto: GuestLoginRequestDto
+    ): BaseResponse<GuestLoginResponseDto>
 
     suspend fun postCheckEmail(
         email: String

--- a/app/src/main/java/com/example/findu/data/dataremote/datasourceimpl/AuthRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/datasourceimpl/AuthRemoteDataSourceImpl.kt
@@ -2,10 +2,13 @@ package com.example.findu.data.dataremote.datasourceimpl
 
 import com.example.findu.data.dataremote.datasource.AuthRemoteDataSource
 import com.example.findu.data.dataremote.model.base.BaseResponse
+import com.example.findu.data.dataremote.model.base.NullableBaseResponse
 import com.example.findu.data.dataremote.model.request.CheckEmailRequestDto
+import com.example.findu.data.dataremote.model.request.GuestLoginRequestDto
 import com.example.findu.data.dataremote.model.request.LoginRequestDto
 import com.example.findu.data.dataremote.model.request.SignupRequestDto
 import com.example.findu.data.dataremote.model.response.CheckEmailResponseDto
+import com.example.findu.data.dataremote.model.response.auth.GuestLoginResponseDto
 import com.example.findu.data.dataremote.model.response.auth.LoginResponseDto
 import com.example.findu.data.dataremote.service.AuthService
 import retrofit2.Response
@@ -16,6 +19,9 @@ class AuthRemoteDataSourceImpl @Inject constructor(
 ) : AuthRemoteDataSource {
     override suspend fun postLogin(loginRequestDto: LoginRequestDto): BaseResponse<LoginResponseDto> =
         authService.postLogin(loginRequestDto=loginRequestDto)
+
+    override suspend fun postGuestLogin(guestLoginRequestDto: GuestLoginRequestDto): BaseResponse<GuestLoginResponseDto> =
+        authService.postGuestLogin(guestLoginRequestDto=guestLoginRequestDto)
 
     override suspend fun postCheckEmail(email: String): BaseResponse<CheckEmailResponseDto> =
         authService.postCheckEmail(CheckEmailRequestDto(email))

--- a/app/src/main/java/com/example/findu/data/dataremote/datasourceimpl/AuthRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/datasourceimpl/AuthRemoteDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.example.findu.data.dataremote.model.request.CheckEmailRequestDto
 import com.example.findu.data.dataremote.model.request.LoginRequestDto
 import com.example.findu.data.dataremote.model.request.SignupRequestDto
 import com.example.findu.data.dataremote.model.response.CheckEmailResponseDto
+import com.example.findu.data.dataremote.model.response.auth.LoginResponseDto
 import com.example.findu.data.dataremote.service.AuthService
 import retrofit2.Response
 import javax.inject.Inject
@@ -13,8 +14,8 @@ import javax.inject.Inject
 class AuthRemoteDataSourceImpl @Inject constructor(
     private val authService: AuthService
 ) : AuthRemoteDataSource {
-    override suspend fun postLogin(email: String, password: String): Response<Unit> =
-        authService.postLogin(LoginRequestDto(email, password))
+    override suspend fun postLogin(loginRequestDto: LoginRequestDto): BaseResponse<LoginResponseDto> =
+        authService.postLogin(loginRequestDto=loginRequestDto)
 
     override suspend fun postCheckEmail(email: String): BaseResponse<CheckEmailResponseDto> =
         authService.postCheckEmail(CheckEmailRequestDto(email))

--- a/app/src/main/java/com/example/findu/data/dataremote/model/base/BaseResponse.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/model/base/BaseResponse.kt
@@ -8,5 +8,5 @@ data class BaseResponse<T>(
     @SerialName("success") val success: Boolean,
     @SerialName("code") val code: Int,
     @SerialName("message") val message: String,
-    @SerialName("data") val data: T
+    @SerialName("data") val data: T? = null
 )

--- a/app/src/main/java/com/example/findu/data/dataremote/model/request/GuestLoginRequestDto.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/model/request/GuestLoginRequestDto.kt
@@ -1,0 +1,10 @@
+package com.example.findu.data.dataremote.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GuestLoginRequestDto(
+    @SerialName("deviceId")
+    val deviceId: String,
+)

--- a/app/src/main/java/com/example/findu/data/dataremote/model/request/LoginRequestDto.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/model/request/LoginRequestDto.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LoginRequestDto(
-    @SerialName("email")
-    val email: String,
-    @SerialName("password")
-    val password: String
+    @SerialName("kakaoId")
+    val kakaoId: Long,
+    @SerialName("deviceId")
+    val deviceId: String,
 )

--- a/app/src/main/java/com/example/findu/data/dataremote/model/response/auth/GuestLoginResponseDto.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/model/response/auth/GuestLoginResponseDto.kt
@@ -1,0 +1,12 @@
+package com.example.findu.data.dataremote.model.response.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GuestLoginResponseDto(
+    @SerialName("userId")
+    val userId: Long,
+    @SerialName("accessToken")
+    val accessToken: String
+)

--- a/app/src/main/java/com/example/findu/data/dataremote/model/response/auth/LoginResponseDto.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/model/response/auth/LoginResponseDto.kt
@@ -1,0 +1,22 @@
+package com.example.findu.data.dataremote.model.response.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LoginResponseDto(
+    @SerialName("userInfo")
+    val userInfo: UserInfoDto? = null,
+    @SerialName("isFirstLogin")
+    val isFirstLogin: Boolean
+)
+
+@Serializable
+data class UserInfoDto(
+    @SerialName("userId")
+    val userId: Long,
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("accessToken")
+    val accessToken: String
+)

--- a/app/src/main/java/com/example/findu/data/dataremote/service/AuthService.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/service/AuthService.kt
@@ -5,22 +5,26 @@ import com.example.findu.data.dataremote.model.request.CheckEmailRequestDto
 import com.example.findu.data.dataremote.model.request.LoginRequestDto
 import com.example.findu.data.dataremote.model.request.SignupRequestDto
 import com.example.findu.data.dataremote.model.response.CheckEmailResponseDto
+import com.example.findu.data.dataremote.model.response.auth.LoginResponseDto
+import com.example.findu.data.dataremote.util.ApiConstraints.API
+import com.example.findu.data.dataremote.util.ApiConstraints.AUTH
+import com.example.findu.data.dataremote.util.ApiConstraints.VERSION
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface AuthService {
-    @POST("/api/v1/auth/login")
+    @POST("/$API/$VERSION/$AUTH/login/kakao")
     suspend fun postLogin(
-        @Body loginRequestBody: LoginRequestDto
-    ): Response<Unit>
+        @Body loginRequestDto: LoginRequestDto
+    ): BaseResponse<LoginResponseDto>
 
-    @POST("/api/v1/auth/check/duplicate-email")
+    @POST("/$API/$VERSION/$AUTH/check/duplicate-email")
     suspend fun postCheckEmail(
         @Body checkEmailRequestDto: CheckEmailRequestDto
     ): BaseResponse<CheckEmailResponseDto>
 
-    @POST("/api/v1/auth/signup")
+    @POST("/$API/$VERSION/$AUTH/signup")
     suspend fun postSignup(
         @Body signupRequestBody: SignupRequestDto
     ): Response<Unit>

--- a/app/src/main/java/com/example/findu/data/dataremote/service/AuthService.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/service/AuthService.kt
@@ -2,9 +2,11 @@ package com.example.findu.data.dataremote.service
 
 import com.example.findu.data.dataremote.model.base.BaseResponse
 import com.example.findu.data.dataremote.model.request.CheckEmailRequestDto
+import com.example.findu.data.dataremote.model.request.GuestLoginRequestDto
 import com.example.findu.data.dataremote.model.request.LoginRequestDto
 import com.example.findu.data.dataremote.model.request.SignupRequestDto
 import com.example.findu.data.dataremote.model.response.CheckEmailResponseDto
+import com.example.findu.data.dataremote.model.response.auth.GuestLoginResponseDto
 import com.example.findu.data.dataremote.model.response.auth.LoginResponseDto
 import com.example.findu.data.dataremote.util.ApiConstraints.API
 import com.example.findu.data.dataremote.util.ApiConstraints.AUTH
@@ -18,6 +20,11 @@ interface AuthService {
     suspend fun postLogin(
         @Body loginRequestDto: LoginRequestDto
     ): BaseResponse<LoginResponseDto>
+
+    @POST("/$API/$VERSION/$AUTH/login/guest")
+    suspend fun postGuestLogin(
+        @Body guestLoginRequestDto: GuestLoginRequestDto
+    ): BaseResponse<GuestLoginResponseDto>
 
     @POST("/$API/$VERSION/$AUTH/check/duplicate-email")
     suspend fun postCheckEmail(

--- a/app/src/main/java/com/example/findu/data/dataremote/util/ApiResponseHandler.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/util/ApiResponseHandler.kt
@@ -6,7 +6,8 @@ import com.example.findu.data.dataremote.model.base.NullableBaseResponse
 fun <T> BaseResponse<T>.handleBaseResponse(): Result<T> =
     when (this.code) {
         in 20000..29999 -> {
-            Result.success(this.data)
+            data?.let { Result.success(it) }
+                ?: Result.failure(IllegalStateException("data is null"))
         }
 
         in 40400..40499 -> {

--- a/app/src/main/java/com/example/findu/data/dataremote/util/ApiResponseHandler.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/util/ApiResponseHandler.kt
@@ -5,16 +5,16 @@ import com.example.findu.data.dataremote.model.base.NullableBaseResponse
 
 fun <T> BaseResponse<T>.handleBaseResponse(): Result<T> =
     when (this.code) {
-        in 20000..29999, in 200..299 -> { 
+        in 200..299 -> { // 성공
             data?.let { Result.success(it) }
                 ?: Result.failure(IllegalStateException("data is null"))
         }
 
-        in 40400..40499, in 400..499 -> { // 클라이언트 에러
+        in 400..499 -> { // 클라이언트 에러
             Result.failure(Exception("Client error : ${this.message}"))
         }
 
-        in 50000..50099, in 500..599 -> { // 서버 에러
+        in 500..599 -> { // 서버 에러
             Result.failure(Exception("Server error : ${this.message}"))
         }
 
@@ -25,15 +25,15 @@ fun <T> BaseResponse<T>.handleBaseResponse(): Result<T> =
 
 fun <T> NullableBaseResponse<T>.handleBaseResponse(): Result<T?> =
     when (this.code) {
-        in 20000..29999, in 200..299 -> {
+        in 200..299 -> { // 성공
             Result.success(this.data)
         }
 
-        in 40400..40499, in 400..499 -> {
+        in 400..499 -> { // 클라이언트 에러
             Result.failure(Exception("Client error : ${this.message}"))
         }
 
-        in 50000..50099, in 500..599 -> {
+        in 500..599 -> { // 서버 에러
             Result.failure(Exception("Server error : ${this.message}"))
         }
 

--- a/app/src/main/java/com/example/findu/data/dataremote/util/ApiResponseHandler.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/util/ApiResponseHandler.kt
@@ -5,16 +5,16 @@ import com.example.findu.data.dataremote.model.base.NullableBaseResponse
 
 fun <T> BaseResponse<T>.handleBaseResponse(): Result<T> =
     when (this.code) {
-        in 20000..29999 -> {
+        in 20000..29999, in 200..299 -> { 
             data?.let { Result.success(it) }
                 ?: Result.failure(IllegalStateException("data is null"))
         }
 
-        in 40400..40499 -> {
+        in 40400..40499, in 400..499 -> { // 클라이언트 에러
             Result.failure(Exception("Client error : ${this.message}"))
         }
 
-        in 50000..50099 -> {
+        in 50000..50099, in 500..599 -> { // 서버 에러
             Result.failure(Exception("Server error : ${this.message}"))
         }
 
@@ -25,15 +25,15 @@ fun <T> BaseResponse<T>.handleBaseResponse(): Result<T> =
 
 fun <T> NullableBaseResponse<T>.handleBaseResponse(): Result<T?> =
     when (this.code) {
-        in 20000..29999 -> {
+        in 20000..29999, in 200..299 -> {
             Result.success(this.data)
         }
 
-        in 40400..40499 -> {
+        in 40400..40499, in 400..499 -> {
             Result.failure(Exception("Client error : ${this.message}"))
         }
 
-        in 50000..50099 -> {
+        in 50000..50099, in 500..599 -> {
             Result.failure(Exception("Server error : ${this.message}"))
         }
 

--- a/app/src/main/java/com/example/findu/data/dataremote/util/Constraints.kt
+++ b/app/src/main/java/com/example/findu/data/dataremote/util/Constraints.kt
@@ -1,0 +1,10 @@
+package com.example.findu.data.dataremote.util
+
+object ApiConstraints {
+    // Common
+    const val API = "api"
+    const val VERSION = "v2"
+
+    // Auth
+    const val AUTH = "auth"
+}

--- a/app/src/main/java/com/example/findu/data/mapper/toDomain/GuestLoginResponseDtoMapper.kt
+++ b/app/src/main/java/com/example/findu/data/mapper/toDomain/GuestLoginResponseDtoMapper.kt
@@ -1,0 +1,10 @@
+package com.example.findu.data.mapper.todomain
+
+import com.example.findu.data.dataremote.model.response.auth.GuestLoginResponseDto
+import com.example.findu.domain.model.GuestLoginData
+
+fun GuestLoginResponseDto.toDomain(): GuestLoginData =
+    GuestLoginData(
+        userId = this.userId,
+        accessToken = this.accessToken
+    )

--- a/app/src/main/java/com/example/findu/data/mapper/todomain/LoginResponseDtoMapper.kt
+++ b/app/src/main/java/com/example/findu/data/mapper/todomain/LoginResponseDtoMapper.kt
@@ -1,0 +1,17 @@
+package com.example.findu.data.mapper.todomain
+
+import com.example.findu.data.dataremote.model.response.auth.LoginResponseDto
+import com.example.findu.domain.model.LoginData
+import com.example.findu.domain.model.UserInfo
+
+fun LoginResponseDto.toDomain(): LoginData =
+    LoginData(
+        isFirstLogin = isFirstLogin,
+        userInfo = userInfo?.let {
+            UserInfo(
+                userId = it.userId,
+                nickname = it.nickname,
+                accessToken = it.accessToken
+            )
+        }
+    )

--- a/app/src/main/java/com/example/findu/data/mapper/torequest/GuestLoginRequestDtoMapper.kt
+++ b/app/src/main/java/com/example/findu/data/mapper/torequest/GuestLoginRequestDtoMapper.kt
@@ -1,0 +1,9 @@
+package com.example.findu.data.mapper.torequest
+
+import com.example.findu.data.dataremote.model.request.GuestLoginRequestDto
+import com.example.findu.data.dataremote.model.request.LoginRequestDto
+import com.example.findu.domain.model.LoginInfo
+
+
+fun String.toRequestDto() =
+    GuestLoginRequestDto(deviceId = this)

--- a/app/src/main/java/com/example/findu/data/mapper/torequest/LoginRequestDtoMapper.kt
+++ b/app/src/main/java/com/example/findu/data/mapper/torequest/LoginRequestDtoMapper.kt
@@ -1,0 +1,8 @@
+package com.example.findu.data.mapper.torequest
+
+import com.example.findu.data.dataremote.model.request.LoginRequestDto
+import com.example.findu.domain.model.LoginInfo
+
+
+fun LoginInfo.toRequestDto() =
+    LoginRequestDto(kakaoId = this.kakaoId, deviceId = this.deviceId)

--- a/app/src/main/java/com/example/findu/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/findu/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.example.findu.data.dataremote.util.handleBaseResponse
 import com.example.findu.data.mapper.todomain.toDomain
 import com.example.findu.data.mapper.torequest.toRequestDto
 import com.example.findu.domain.model.CheckEmailData
+import com.example.findu.domain.model.GuestLoginData
 import com.example.findu.domain.model.LoginData
 import com.example.findu.domain.model.LoginInfo
 import com.example.findu.domain.repository.AuthRepository
@@ -17,6 +18,11 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun postLogin(loginInfo: LoginInfo): Result<LoginData> =
         runCatching {
             authRemoteDataSource.postLogin(loginRequestDto = loginInfo.toRequestDto()).handleBaseResponse().getOrThrow().toDomain()
+        }
+
+    override suspend fun postGuestLogin(deviceId:String): Result<GuestLoginData> =
+        runCatching {
+            authRemoteDataSource.postGuestLogin(guestLoginRequestDto = deviceId.toRequestDto()).handleBaseResponse().getOrThrow().toDomain()
         }
 
     override suspend fun postCheckEmail(email: String): Result<CheckEmailData> =

--- a/app/src/main/java/com/example/findu/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/findu/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -3,7 +3,10 @@ package com.example.findu.data.repositoryimpl
 import com.example.findu.data.dataremote.datasource.AuthRemoteDataSource
 import com.example.findu.data.dataremote.util.handleBaseResponse
 import com.example.findu.data.mapper.todomain.toDomain
+import com.example.findu.data.mapper.torequest.toRequestDto
 import com.example.findu.domain.model.CheckEmailData
+import com.example.findu.domain.model.LoginData
+import com.example.findu.domain.model.LoginInfo
 import com.example.findu.domain.repository.AuthRepository
 import retrofit2.Response
 import javax.inject.Inject
@@ -11,20 +14,9 @@ import javax.inject.Inject
 class AuthRepositoryImpl @Inject constructor(
     private val authRemoteDataSource: AuthRemoteDataSource
 ) : AuthRepository {
-    override suspend fun postLogin(email: String, password: String): Result<String> =
+    override suspend fun postLogin(loginInfo: LoginInfo): Result<LoginData> =
         runCatching {
-            val response: Response<Unit> = authRemoteDataSource.postLogin(email, password)
-
-            if (response.isSuccessful) {
-                val accessToken = response.headers()["Authorization"]?.removePrefix("Bearer ")
-                if (!accessToken.isNullOrEmpty()) {
-                    return@runCatching accessToken
-                } else {
-                    throw Exception("Access Token이 응답 헤더에 없음")
-                }
-            } else {
-                throw Exception("로그인 실패: ${response.code()}")
-            }
+            authRemoteDataSource.postLogin(loginRequestDto = loginInfo.toRequestDto()).handleBaseResponse().getOrThrow().toDomain()
         }
 
     override suspend fun postCheckEmail(email: String): Result<CheckEmailData> =

--- a/app/src/main/java/com/example/findu/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/findu/di/UseCaseModule.kt
@@ -16,6 +16,7 @@ import com.example.findu.domain.usecase.GetBreedValidationUseCase
 import com.example.findu.domain.usecase.GetHomeUseCase
 import com.example.findu.domain.usecase.GetSearchUseCase
 import com.example.findu.domain.usecase.PostCheckEmailUseCase
+import com.example.findu.domain.usecase.PostGuestLoginUseCase
 import com.example.findu.domain.usecase.PostLoginUseCase
 import com.example.findu.domain.usecase.PostSignupUseCase
 import com.example.findu.domain.usecase.interest.DeleteInterestProtectingAnimalUseCase
@@ -175,6 +176,12 @@ object UseCaseModule {
     fun providePostLoginUseCase(
         authRepository: AuthRepository,
     ): PostLoginUseCase = PostLoginUseCase(authRepository)
+
+    @Provides
+    @Singleton
+    fun providePostGuestLoginUseCase(
+        authRepository: AuthRepository,
+    ): PostGuestLoginUseCase = PostGuestLoginUseCase(authRepository)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/example/findu/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/findu/di/UseCaseModule.kt
@@ -174,8 +174,7 @@ object UseCaseModule {
     @Singleton
     fun providePostLoginUseCase(
         authRepository: AuthRepository,
-        tokenRepository: TokenRepository
-    ): PostLoginUseCase = PostLoginUseCase(authRepository, tokenRepository)
+    ): PostLoginUseCase = PostLoginUseCase(authRepository)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/example/findu/domain/model/AuthData.kt
+++ b/app/src/main/java/com/example/findu/domain/model/AuthData.kt
@@ -3,3 +3,19 @@ package com.example.findu.domain.model
 data class CheckEmailData(
     val isDuplicateEmail: Boolean
 )
+
+data class LoginInfo(
+    val kakaoId: Long,
+    val deviceId:String
+)
+
+data class LoginData(
+    val isFirstLogin: Boolean,
+    val userInfo: UserInfo?
+)
+
+data class UserInfo(
+    val userId: Long,
+    val nickname: String,
+    val accessToken: String
+)

--- a/app/src/main/java/com/example/findu/domain/model/AuthData.kt
+++ b/app/src/main/java/com/example/findu/domain/model/AuthData.kt
@@ -14,6 +14,11 @@ data class LoginData(
     val userInfo: UserInfo?
 )
 
+data class GuestLoginData(
+    val userId: Long,
+    val accessToken: String
+)
+
 data class UserInfo(
     val userId: Long,
     val nickname: String,

--- a/app/src/main/java/com/example/findu/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/findu/domain/repository/AuthRepository.kt
@@ -1,12 +1,13 @@
 package com.example.findu.domain.repository
 
 import com.example.findu.domain.model.CheckEmailData
+import com.example.findu.domain.model.LoginData
+import com.example.findu.domain.model.LoginInfo
 
 interface AuthRepository {
     suspend fun postLogin(
-        email: String,
-        password: String
-    ): Result<String>
+        loginInfo: LoginInfo
+    ): Result<LoginData>
 
     suspend fun postCheckEmail(
         email: String

--- a/app/src/main/java/com/example/findu/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/findu/domain/repository/AuthRepository.kt
@@ -1,6 +1,7 @@
 package com.example.findu.domain.repository
 
 import com.example.findu.domain.model.CheckEmailData
+import com.example.findu.domain.model.GuestLoginData
 import com.example.findu.domain.model.LoginData
 import com.example.findu.domain.model.LoginInfo
 
@@ -8,6 +9,10 @@ interface AuthRepository {
     suspend fun postLogin(
         loginInfo: LoginInfo
     ): Result<LoginData>
+
+    suspend fun postGuestLogin(
+        deviceId: String
+    ): Result<GuestLoginData>
 
     suspend fun postCheckEmail(
         email: String

--- a/app/src/main/java/com/example/findu/domain/usecase/PostGuestLoginUseCase.kt
+++ b/app/src/main/java/com/example/findu/domain/usecase/PostGuestLoginUseCase.kt
@@ -1,0 +1,14 @@
+package com.example.findu.domain.usecase
+
+import com.example.findu.domain.model.GuestLoginData
+import com.example.findu.domain.repository.AuthRepository
+
+class PostGuestLoginUseCase(
+    private val authRepository: AuthRepository,
+) {
+    suspend fun postGuestLogin(
+        deviceId:String
+    ): Result<GuestLoginData> = authRepository.postGuestLogin(
+        deviceId = deviceId
+    )
+}

--- a/app/src/main/java/com/example/findu/domain/usecase/PostLoginUseCase.kt
+++ b/app/src/main/java/com/example/findu/domain/usecase/PostLoginUseCase.kt
@@ -1,19 +1,16 @@
 package com.example.findu.domain.usecase
 
+import com.example.findu.domain.model.LoginData
+import com.example.findu.domain.model.LoginInfo
 import com.example.findu.domain.repository.AuthRepository
 import com.example.findu.domain.repository.TokenRepository
 
 class PostLoginUseCase(
     private val authRepository: AuthRepository,
-    private val tokenRepository: TokenRepository
 ) {
     suspend fun postLogin(
-        email: String,
-        password: String
-    ): Result<Unit> = authRepository.postLogin(
-        email = email,
-        password = password
-    ).mapCatching { accessToken ->
-        tokenRepository.setAccessToken(accessToken)
-    }
+        loginInfo:LoginInfo
+    ): Result<LoginData> = authRepository.postLogin(
+        loginInfo = loginInfo
+    )
 }

--- a/app/src/main/java/com/example/findu/presentation/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/findu/presentation/ui/login/LoginActivity.kt
@@ -17,6 +17,7 @@ import com.example.findu.presentation.ui.onboarding.OnboardingActivity
 import com.example.findu.presentation.util.extension.showToast
 import com.example.findu.presentation.util.kakao.KakaoLoginHelper
 import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -36,7 +37,20 @@ class LoginActivity : ComponentActivity() {
             val callback: (OAuthToken?, Throwable?) -> Unit = { oAuthToken, _ ->
                 if (oAuthToken != null) {
                     Log.d(TAG, "oAuth_AccessToken: ${oAuthToken.accessToken}")
-                    loginViewModel.checkRegisteredUser(oAuthToken.accessToken)
+
+                    UserApiClient.instance.me { user, error ->
+                        if (error != null) {
+                            Log.e(TAG, "사용자 정보 요청 실패", error)
+                            return@me
+                        }
+
+                        val kakaoId = user?.id
+                        if (kakaoId != null) {
+                            loginViewModel.postLogin(kakaoId = kakaoId)
+                        } else {
+                            Log.w(TAG, "KakaoId is null")
+                        }
+                    }
                 }
             }
             LoginScreen(

--- a/app/src/main/java/com/example/findu/presentation/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/findu/presentation/ui/login/LoginActivity.kt
@@ -61,8 +61,9 @@ class LoginActivity : ComponentActivity() {
                     )
                 },
                 withoutSignUpButtonClicked = {
-                    this.showToast(message = getString(R.string.login_without_signup_toast_message))
-                    loginViewModel.startMainActivity()
+                    loginViewModel.postGuestLogin{
+                        this.showToast(message = getString(R.string.login_without_signup_toast_message))
+                    }
                 },
             )
 

--- a/app/src/main/java/com/example/findu/presentation/ui/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/findu/presentation/ui/login/viewmodel/LoginViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.findu.domain.model.LoginInfo
+import com.example.findu.domain.usecase.PostGuestLoginUseCase
 import com.example.findu.domain.usecase.PostLoginUseCase
 import com.example.findu.domain.usecase.token.SetAccessTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,6 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val loginUseCase: PostLoginUseCase,
+    private val guestLoginUseCase: PostGuestLoginUseCase,
     private val setAccessTokenUseCase: SetAccessTokenUseCase,
 ) : ViewModel() {
     private val _startMainActivity = MutableSharedFlow<Unit>()
@@ -26,13 +28,14 @@ class LoginViewModel @Inject constructor(
 
 
     private val deviceId = UUID.randomUUID().toString()
+
     fun postLogin(kakaoId: Long) {
         viewModelScope.launch {
             loginUseCase.postLogin(LoginInfo(kakaoId = kakaoId, deviceId = deviceId)).onSuccess { loginData ->
-                setAccessTokenUseCase(accessToken = loginData.userInfo!!.accessToken)
                 if (loginData.isFirstLogin) {
                     startOnboardingActivity()
                 } else {
+                    setAccessTokenUseCase(accessToken = loginData.userInfo!!.accessToken)
                     startMainActivity()
                 }
             }.onFailure { e ->
@@ -42,7 +45,23 @@ class LoginViewModel @Inject constructor(
     }
 
 
-    fun startMainActivity() {
+    fun postGuestLogin(onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            guestLoginUseCase.postGuestLogin(deviceId = deviceId)
+                .onSuccess { loginData ->
+                    setAccessTokenUseCase(accessToken = loginData.accessToken)
+                    onSuccess()
+                    startMainActivity()
+                }
+                .onFailure { e ->
+                    Log.d("http", "Error Message: : $e")
+                }
+        }
+    }
+
+
+
+    private fun startMainActivity() {
         viewModelScope.launch {
             _startMainActivity.emit(Unit)
         }
@@ -52,10 +71,6 @@ class LoginViewModel @Inject constructor(
         viewModelScope.launch {
             _startOnboardingActivity.emit(Unit)
         }
-    }
-
-    private fun dummyRegisteredCheckLogic(oAuthToken: String): Boolean {
-        return oAuthToken.isEmpty()
     }
 
 }

--- a/app/src/main/java/com/example/findu/presentation/ui/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/findu/presentation/ui/login/viewmodel/LoginViewModel.kt
@@ -3,14 +3,14 @@ package com.example.findu.presentation.ui.login.viewmodel
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.findu.domain.model.LoginInfo
 import com.example.findu.domain.usecase.PostLoginUseCase
 import com.example.findu.domain.usecase.token.SetAccessTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
@@ -18,40 +18,26 @@ class LoginViewModel @Inject constructor(
     private val loginUseCase: PostLoginUseCase,
     private val setAccessTokenUseCase: SetAccessTokenUseCase,
 ) : ViewModel() {
-    private val _loginResult = MutableStateFlow<Boolean?>(null)
-    val loginResult = _loginResult.asStateFlow()
-
     private val _startMainActivity = MutableSharedFlow<Unit>()
     val startMainActivity: SharedFlow<Unit> = _startMainActivity
 
     private val _startOnboardingActivity = MutableSharedFlow<Unit>()
     val startOnboardingActivity: SharedFlow<Unit> = _startOnboardingActivity
 
-    fun postLogin(email: String, password: String) {
+
+    private val deviceId = UUID.randomUUID().toString()
+    fun postLogin(kakaoId: Long) {
         viewModelScope.launch {
-            loginUseCase.postLogin(email, password).fold(
-                onSuccess = {
-                    _loginResult.value = true
-                },
-                onFailure = { _loginResult.value = false }
-            )
-        }
-    }
-
-    fun setAccessToken(accessToken:String){
-        setAccessTokenUseCase(accessToken)
-    }
-
-    fun checkRegisteredUser(oAuthToken:String){
-        //TODO: 회원가입 여부 API 나오면 oAuthToken인자로 넣어서 호출
-        val response = dummyRegisteredCheckLogic(oAuthToken)
-
-        if (response){
-            //TODO: 로그인 API 호출 후 응답으로 받은 accessToken 저장
-//            startMainActivity()
-            startOnboardingActivity()
-        }else{
-            startOnboardingActivity()
+            loginUseCase.postLogin(LoginInfo(kakaoId = kakaoId, deviceId = deviceId)).onSuccess { loginData ->
+                setAccessTokenUseCase(accessToken = loginData.userInfo!!.accessToken)
+                if (loginData.isFirstLogin) {
+                    startOnboardingActivity()
+                } else {
+                    startMainActivity()
+                }
+            }.onFailure { e ->
+                Log.d("http", "Error Message: : $e")
+            }
         }
     }
 
@@ -68,7 +54,7 @@ class LoginViewModel @Inject constructor(
         }
     }
 
-    private fun dummyRegisteredCheckLogic(oAuthToken: String):Boolean{
+    private fun dummyRegisteredCheckLogic(oAuthToken: String): Boolean {
         return oAuthToken.isEmpty()
     }
 

--- a/app/src/main/java/com/example/findu/presentation/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/example/findu/presentation/ui/splash/SplashActivity.kt
@@ -41,8 +41,7 @@ class SplashActivity : AppCompatActivity() {
             if (accessToken.isEmpty()) {
                 navigateToLogin()
             } else {
-                navigateToLogin()
-//                navigateToMain()
+                navigateToMain()
             }
         }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #74

## Work Description 📝
- 카카오 로그인구현
	- 첫 로그인 유저는 회원가입 후 토큰을 저장하기위해 isFirstLogin = false일 때만 토큰을 저장하도록 하였습니다.
- 비회원 로그인구현
	- 비회원 로그인은 성공하면 바로 토큰을 저장합니다.

- 자주 쓰이는 API 상수 정리
	- 반복되어 쓰이거나 편한 버전관리를 위하여 상수처리해두었습니다.
- 개발, 운영 서버 base.url 분리, 적용
	- 현재 개발과 운영서버가 분리되어있어 base.url을 나누어 로컬프로퍼티에 저장하고 빌드타입에서 이를 분기처리 해두었습니다.
- 서버 응답 핸들링 함수 수정
	- 서버측과 논의해보니 v2 api 부터는 응답 코드가 3자리로 변경되어 이에 맞게 수정해두었습니다.

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 카카오 ID 기반 로그인 도입 및 첫 로그인 시 온보딩 분기.
  - 게스트 로그인 추가(디바이스 ID 사용).
- 리팩터링
  - API 경로 v2 및 상수화, 응답 처리 표준화(HTTP 2xx/4xx/5xx)와 데이터 null 안전성 강화.
  - 로그인/도메인 모델·매퍼 정비, UseCase/Repository/뷰모델 연동 구조 개선.
  - 스플래시: 토큰 존재 시 바로 메인 화면 진입.
- 작업(Chores)
  - 빌드 타입별 BASE_URL 분리(Release/Debug), Debug 타입 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->