### PR TITLE
[feat] #111 디스코드 에러 알림 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ android {
         buildConfigField("String", "NAVER_CLIENT_SECRET", properties["NAVER_CLIENT_SECRET"].toString())
         buildConfigField("String", "KAKAO_NATIVE_APP_KEY", properties["kakao.native.app.key"].toString())
         manifestPlaceholders["KAKAO_NATIVE_APP_KEY_MANIFEST"] = properties["kakao.native.app.key.manifest"].toString()
+        buildConfigField("String", "DISCORD_WEBHOOK_URL", properties["DISCORD_WEBHOOK_URL"].toString())
     }
 
     signingConfigs {

--- a/app/src/main/java/com/kuit/findu/data/dataremote/service/WebhookService.kt
+++ b/app/src/main/java/com/kuit/findu/data/dataremote/service/WebhookService.kt
@@ -1,0 +1,14 @@
+package com.kuit.findu.data.dataremote.service
+
+import com.kuit.findu.domain.model.DiscordLogBody
+import retrofit2.http.Body
+import retrofit2.http.POST
+import retrofit2.http.Url
+
+interface WebhookService {
+    @POST
+    suspend fun sendLog(
+        @Url webhookUrl: String,
+        @Body body: DiscordLogBody
+    )
+}

--- a/app/src/main/java/com/kuit/findu/data/dataremote/util/DiscordLogger.kt
+++ b/app/src/main/java/com/kuit/findu/data/dataremote/util/DiscordLogger.kt
@@ -1,0 +1,42 @@
+package com.kuit.findu.data.dataremote.util
+
+import com.kuit.findu.data.dataremote.service.WebhookService
+import com.kuit.findu.domain.model.DiscordLogBody
+import com.kuit.findu.domain.repository.UserInfoRepository
+import retrofit2.HttpException
+import javax.inject.Inject
+
+class DiscordLogger @Inject constructor(
+    private val webhookService: WebhookService,
+    private val userInfoRepository: UserInfoRepository,
+    private val webhookUrl: String,
+) {
+
+    suspend fun logServerError(
+        code: Int,
+        method: String,
+        url: String,
+    ) {
+        val deviceId = userInfoRepository.getDeviceId()
+        val nickname = userInfoRepository.getNickname()
+
+        val body = DiscordLogBody(
+            content = """
+            🚨 **Server Error 발생**
+            
+            👤 User
+            - Nickname: $nickname
+            - DeviceId: $deviceId
+            
+            🌐 Request
+            - Method: $method
+            - Url: $url
+            - Code: $code
+            """.trimIndent()
+        )
+
+        runCatching {
+            webhookService.sendLog(webhookUrl, body)
+        }
+    }
+}

--- a/app/src/main/java/com/kuit/findu/data/dataremote/util/DiscordLogger.kt
+++ b/app/src/main/java/com/kuit/findu/data/dataremote/util/DiscordLogger.kt
@@ -3,7 +3,6 @@ package com.kuit.findu.data.dataremote.util
 import com.kuit.findu.data.dataremote.service.WebhookService
 import com.kuit.findu.domain.model.DiscordLogBody
 import com.kuit.findu.domain.repository.UserInfoRepository
-import retrofit2.HttpException
 import javax.inject.Inject
 
 class DiscordLogger @Inject constructor(

--- a/app/src/main/java/com/kuit/findu/data/dataremote/util/ErrorTrackingInterceptor.kt
+++ b/app/src/main/java/com/kuit/findu/data/dataremote/util/ErrorTrackingInterceptor.kt
@@ -2,13 +2,18 @@ package com.kuit.findu.data.dataremote.util
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.crashlytics.recordException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
 class ErrorTrackingInterceptor @Inject constructor(
     private val firebaseCrashlytics: FirebaseCrashlytics,
+    private val discordLogger: DiscordLogger,
 ) : Interceptor {
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val response: Response
@@ -16,27 +21,34 @@ class ErrorTrackingInterceptor @Inject constructor(
         try {
             response = chain.proceed(request)
         } catch (e: Exception) {
-            // 1. 네트워크 자체가 끊긴 경우 등 (IOException)
             firebaseCrashlytics.recordException(e)
             throw e
         }
 
-        // 2. 서버에서 응답은 왔으나 4xx, 5xx 에러인 경우
         if (!response.isSuccessful) {
             val code = response.code
-
             val url = request.url.toString()
 
-            // Crashlytics에 상세 정보 기록
-            val exceptionMessage = when (response.code) {
-                in (400..499) -> "Client $code Error"
-                in (500..599) -> "Server $code Error"
+            val exceptionMessage = when (code) {
+                in 400..499 -> "Client $code Error"
+                in 500..599 -> "Server $code Error"
                 else -> "Unknown $code Error"
             }
+
             firebaseCrashlytics.recordException(Exception(exceptionMessage)) {
                 key("api_method", request.method)
                 key("api_url", url)
                 key("api_status", code)
+            }
+
+            if (code in 500..599) {
+                CoroutineScope(Dispatchers.IO).launch {
+                    discordLogger.logServerError(
+                        code = code,
+                        method = request.method,
+                        url = url
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/kuit/findu/di/LogModule.kt
+++ b/app/src/main/java/com/kuit/findu/di/LogModule.kt
@@ -1,0 +1,27 @@
+package com.kuit.findu.di
+
+import com.kuit.findu.data.dataremote.service.WebhookService
+import com.kuit.findu.data.dataremote.util.DiscordLogger
+import com.kuit.findu.domain.repository.UserInfoRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LogModule {
+
+    @Provides
+    @Singleton
+    fun provideDiscordLogger(
+        webhookService: WebhookService,
+        userInfoRepository: UserInfoRepository,
+    ): DiscordLogger =
+        DiscordLogger(
+            webhookService,
+            userInfoRepository,
+            BuildConfig.DISCORD_WEBHOOK_URL,
+        )
+}

--- a/app/src/main/java/com/kuit/findu/di/LogModule.kt
+++ b/app/src/main/java/com/kuit/findu/di/LogModule.kt
@@ -1,5 +1,6 @@
 package com.kuit.findu.di
 
+import com.kuit.findu.BuildConfig
 import com.kuit.findu.data.dataremote.service.WebhookService
 import com.kuit.findu.data.dataremote.util.DiscordLogger
 import com.kuit.findu.domain.repository.UserInfoRepository
@@ -12,7 +13,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object LogModule {
-
     @Provides
     @Singleton
     fun provideDiscordLogger(

--- a/app/src/main/java/com/kuit/findu/di/LogNetworkModule.kt
+++ b/app/src/main/java/com/kuit/findu/di/LogNetworkModule.kt
@@ -1,0 +1,42 @@
+package com.kuit.findu.di
+
+import com.kuit.findu.data.dataremote.service.WebhookService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import jakarta.inject.Named
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LogNetworkModule {
+
+    @Provides
+    @Singleton
+    @Named("webhook")
+    fun provideWebhookOkHttpClient(): OkHttpClient =
+        OkHttpClient.Builder().build()
+
+    @Provides
+    @Singleton
+    @Named("webhook")
+    fun provideWebhookRetrofit(
+        @Named("webhook") okHttpClient: OkHttpClient
+    ): Retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://discord.com/")
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideWebhookService(
+        @Named("webhook") retrofit: Retrofit
+    ): WebhookService =
+        retrofit.create(WebhookService::class.java)
+}

--- a/app/src/main/java/com/kuit/findu/di/LogNetworkModule.kt
+++ b/app/src/main/java/com/kuit/findu/di/LogNetworkModule.kt
@@ -5,10 +5,10 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import jakarta.inject.Named
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module

--- a/app/src/main/java/com/kuit/findu/di/NetworkModule.kt
+++ b/app/src/main/java/com/kuit/findu/di/NetworkModule.kt
@@ -8,6 +8,7 @@ import com.kuit.findu.BuildConfig.DEBUG
 import com.kuit.findu.data.datalocal.datasource.TokenLocalDataSource
 import com.kuit.findu.data.dataremote.util.AuthAuthenticator
 import com.kuit.findu.data.dataremote.util.AuthInterceptor
+import com.kuit.findu.data.dataremote.util.DiscordLogger
 import com.kuit.findu.data.dataremote.util.ErrorTrackingInterceptor
 import dagger.Module
 import dagger.Provides
@@ -85,8 +86,12 @@ object NetworkModule {
     @Singleton
     fun provideErrorTrackingInterceptor(
         firebaseCrashlytics: FirebaseCrashlytics,
+        discordLogger: DiscordLogger
     ): ErrorTrackingInterceptor {
-        return ErrorTrackingInterceptor(firebaseCrashlytics)
+        return ErrorTrackingInterceptor(
+            firebaseCrashlytics= firebaseCrashlytics,
+            discordLogger = discordLogger
+        )
     }
 
     @ExperimentalSerializationApi
@@ -103,4 +108,5 @@ object NetworkModule {
                 json.asConverterFactory(requireNotNull("application/json".toMediaTypeOrNull()))
             )
             .build()
+
 }

--- a/app/src/main/java/com/kuit/findu/di/NetworkModule.kt
+++ b/app/src/main/java/com/kuit/findu/di/NetworkModule.kt
@@ -108,5 +108,4 @@ object NetworkModule {
                 json.asConverterFactory(requireNotNull("application/json".toMediaTypeOrNull()))
             )
             .build()
-
 }

--- a/app/src/main/java/com/kuit/findu/domain/model/DiscordLogBody.kt
+++ b/app/src/main/java/com/kuit/findu/domain/model/DiscordLogBody.kt
@@ -1,0 +1,5 @@
+package com.kuit.findu.domain.model
+
+data class DiscordLogBody(
+    val content: String
+)


### PR DESCRIPTION
## Related issue 🛠
- closed #111

## Work Description 📝
- 서버 500번대 에러나면 디코로 알림오도록 해두었습니다

## Screenshot 📸
<img width="679" height="313" alt="Group 192" src="https://github.com/user-attachments/assets/35482630-009b-4c37-a502-31f06281e8eb" />

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Discord 웹훅을 통한 서버 오류 로그 전송 기능을 추가했습니다 (앱 설정에서 웹훅 URL 사용).
* **Chores**
  * 오류 추적 및 로깅 관련 의존성/구성 보완으로 안정성 모니터링을 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->